### PR TITLE
sometimes error msg is nil

### DIFF
--- a/lib/dress_socks/errors.rb
+++ b/lib/dress_socks/errors.rb
@@ -1,6 +1,6 @@
 module DressSocks
   class SOCKSError < RuntimeError
-    def initialize(msg)
+    def initialize(msg = nil)
       super
     end
 


### PR DESCRIPTION
I'm using DressSocks for a side project, and sometimes I have noticed that it will blow up like this:

```
ArgumentError: wrong number of arguments (given 0, expected 1)
/Users/grantammons/.asdf/installs/ruby/3.1.0/lib/ruby/gems/3.1.0/gems/dress_socks-0.1.2/lib/dress_socks/errors.rb:3:in `initialize'
```

This modification allows me to consume the actual error that occurred upstream.