### PR TITLE
Handle case where code can be nil

### DIFF
--- a/lib/dress_socks/errors.rb
+++ b/lib/dress_socks/errors.rb
@@ -45,7 +45,7 @@ module DressSocks
       end
     end
 
-    def self.for_response_code(code)
+    def self.for_response_code(code = nil)
       case code
       when 1
         ServerFailure


### PR DESCRIPTION
This raises an ArgumentError if a code is not passed in.